### PR TITLE
Feature/add migrations visit medic

### DIFF
--- a/app/Models/LastLocation.php
+++ b/app/Models/LastLocation.php
@@ -12,10 +12,21 @@ class LastLocation extends Model
 
     protected $table = 'last_locations';
 
-    protected $fillable = ['user_id','latitude','longitude'];
+    protected $fillable = [
+        'user_id',
+        'latitude',
+        'longitude',
+        'precision',
+        'velocidad',
+        'registrado_en',
+    ];
+
     protected $casts = [
         'latitude'  => 'float',
         'longitude' => 'float',
+        'precision' => 'float',
+        'velocidad' => 'float',
+        'registrado_en' => 'datetime',
     ];
 
     public function user(): BelongsTo

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -10,14 +10,32 @@ class Location extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id','latitude','longitude'];
+    protected $fillable = [
+        'user_id',
+        'latitude',
+        'longitude',
+        'precision',
+        'velocidad',
+        'registrado_en',
+        'jornada_id',
+    ];
+
     protected $casts = [
         'latitude'  => 'float',
         'longitude' => 'float',
+        'precision' => 'float',
+        'velocidad' => 'float',
+        'registrado_en' => 'datetime',
     ];
 
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    // Relación a jornada (nuevo)
+    public function jornada(): BelongsTo
+    {
+        return $this->belongsTo(Jornada::class, 'jornada_id');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,47 +2,46 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
     protected $fillable = [
         'name',
+        'apellidos',
+        'usuario',      // login opcional
         'email',
         'password',
-        'device'
+        'device',
+        'sucursal_id',
+        'rol',
+        'estado',       // OFF/ON
     ];
 
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var array<int, string>
-     */
     protected $hidden = [
         'password',
         'remember_token',
     ];
 
-    /**
-     * The attributes that should be cast.
-     *
-     * @var array<string, string>
-     */
     protected $casts = [
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    // Relación con sucursal (si ya creaste la tabla sucursales)
+    public function sucursal(): BelongsTo
+    {
+        return $this->belongsTo(Sucursal::class, 'sucursal_id');
+    }
 
     // Un usuario tiene muchas ubicaciones (histórico)
     public function locations(): HasMany
@@ -54,5 +53,17 @@ class User extends Authenticatable
     public function lastLocation(): HasOne
     {
         return $this->hasOne(LastLocation::class);
+    }
+
+    // Jornadas del usuario (nuevo)
+    public function jornadas(): HasMany
+    {
+        return $this->hasMany(Jornada::class, 'usuario_id');
+    }
+
+    // Visitas del usuario (nuevo)
+    public function visitas(): HasMany
+    {
+        return $this->hasMany(Visita::class, 'usuario_id');
     }
 }

--- a/database/migrations/2026_01_03_000001_create_sucursales_table.php
+++ b/database/migrations/2026_01_03_000001_create_sucursales_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('sucursales')) {
+            Schema::create('sucursales', function (Blueprint $table) {
+                $table->id();
+                $table->string('nombre');
+                $table->string('ciudad')->nullable();
+                $table->string('direccion')->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sucursales');
+    }
+};

--- a/database/migrations/2026_01_03_000002_add_campos_es_to_users_table.php
+++ b/database/migrations/2026_01_03_000002_add_campos_es_to_users_table.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+return new class extends Migration {
+    public function up(): void
+    {
+        // Agrega columnas sin romper lo existente
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'apellidos')) {
+                $table->string('apellidos')->nullable()->after('name');
+            }
+            if (!Schema::hasColumn('users', 'usuario')) {
+                $table->string('usuario')->nullable()->after('email'); // login opcional
+            }
+            if (!Schema::hasColumn('users', 'sucursal_id')) {
+                $table->foreignId('sucursal_id')
+                    ->nullable()
+                    ->constrained('sucursales')
+                    ->nullOnDelete();
+            }
+            if (!Schema::hasColumn('users', 'rol')) {
+                $table->string('rol', 50)->default('visitador');
+            }
+            if (!Schema::hasColumn('users', 'estado')) {
+                // OFF / ON según tu regla
+                $table->string('estado', 10)->default('OFF');
+            }
+        });
+
+        // Índices útiles
+        DB::statement("CREATE INDEX IF NOT EXISTS users_sucursal_id_index ON users(sucursal_id)");
+        DB::statement("CREATE INDEX IF NOT EXISTS users_estado_index ON users(estado)");
+        DB::statement("CREATE INDEX IF NOT EXISTS users_rol_index ON users(rol)");
+
+        // Unique parcial para usuario (permite múltiples NULL en Postgres)
+        DB::statement("CREATE UNIQUE INDEX IF NOT EXISTS users_usuario_unique ON users(usuario) WHERE usuario IS NOT NULL");
+
+        // Backfill (por si existieran nulos)
+        DB::table('users')->whereNull('estado')->update(['estado' => 'OFF']);
+        DB::table('users')->whereNull('rol')->update(['rol' => 'visitador']);
+    }
+
+    public function down(): void
+    {
+        // Ojo: bajar esto puede fallar si ya hay dependencias creadas por otros cambios.
+        DB::statement("DROP INDEX IF EXISTS users_usuario_unique");
+        DB::statement("DROP INDEX IF EXISTS users_sucursal_id_index");
+        DB::statement("DROP INDEX IF EXISTS users_estado_index");
+        DB::statement("DROP INDEX IF EXISTS users_rol_index");
+
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'sucursal_id')) {
+                $table->dropConstrainedForeignId('sucursal_id');
+            }
+            if (Schema::hasColumn('users', 'estado')) $table->dropColumn('estado');
+            if (Schema::hasColumn('users', 'rol')) $table->dropColumn('rol');
+            if (Schema::hasColumn('users', 'usuario')) $table->dropColumn('usuario');
+            if (Schema::hasColumn('users', 'apellidos')) $table->dropColumn('apellidos');
+        });
+    }
+};

--- a/database/migrations/2026_01_03_000003_create_jornadas_table.php
+++ b/database/migrations/2026_01_03_000003_create_jornadas_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('jornadas')) {
+            Schema::create('jornadas', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('usuario_id')
+                    ->constrained('users')
+                    ->cascadeOnDelete();
+
+                $table->date('fecha');
+
+                // Horario planificado (snapshot del día)
+                $table->time('hora_inicio_plan')->default('08:00:00');
+                $table->time('hora_inicio_almuerzo_plan')->default('12:00:00');
+                $table->time('hora_fin_almuerzo_plan')->default('14:00:00');
+                $table->time('hora_fin_plan')->default('18:00:00');
+
+                // Marcadores reales
+                $table->timestamp('inicio_real')->nullable();
+                $table->timestamp('inicio_almuerzo_real')->nullable();
+                $table->timestamp('fin_almuerzo_real')->nullable();
+                $table->timestamp('fin_real')->nullable();
+
+                $table->string('estado', 20)->default('pendiente'); // pendiente|activa|pausada|finalizada
+                $table->boolean('tracking_habilitado')->default(false);
+
+                $table->timestamps();
+
+                $table->unique(['usuario_id', 'fecha'], 'jornadas_usuario_fecha_unique');
+                $table->index('estado');
+                $table->index('tracking_habilitado');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jornadas');
+    }
+};

--- a/database/migrations/2026_01_03_000004_add_campos_es_to_locations_tables.php
+++ b/database/migrations/2026_01_03_000004_add_campos_es_to_locations_tables.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+return new class extends Migration {
+    public function up(): void
+    {
+        // Tabla locations (existente)
+        Schema::table('locations', function (Blueprint $table) {
+            if (!Schema::hasColumn('locations', 'jornada_id')) {
+                $table->foreignId('jornada_id')
+                    ->nullable()
+                    ->constrained('jornadas')
+                    ->nullOnDelete();
+            }
+            if (!Schema::hasColumn('locations', 'precision')) {
+                $table->float('precision')->nullable();
+            }
+            if (!Schema::hasColumn('locations', 'velocidad')) {
+                $table->float('velocidad')->nullable();
+            }
+            if (!Schema::hasColumn('locations', 'registrado_en')) {
+                $table->timestamp('registrado_en')->nullable();
+            }
+        });
+
+        // Backfill: registrado_en = created_at (no rompe el tracking actual)
+        DB::table('locations')->whereNull('registrado_en')->update([
+            'registrado_en' => DB::raw('created_at')
+        ]);
+
+        // Tabla last_locations (existente)
+        Schema::table('last_locations', function (Blueprint $table) {
+            if (!Schema::hasColumn('last_locations', 'precision')) {
+                $table->float('precision')->nullable();
+            }
+            if (!Schema::hasColumn('last_locations', 'velocidad')) {
+                $table->float('velocidad')->nullable();
+            }
+            if (!Schema::hasColumn('last_locations', 'registrado_en')) {
+                $table->timestamp('registrado_en')->nullable();
+            }
+        });
+
+        DB::table('last_locations')->whereNull('registrado_en')->update([
+            'registrado_en' => DB::raw('created_at')
+        ]);
+
+        DB::statement("CREATE INDEX IF NOT EXISTS locations_user_created_idx ON locations(user_id, created_at)");
+        DB::statement("CREATE INDEX IF NOT EXISTS locations_jornada_registrado_idx ON locations(jornada_id, registrado_en)");
+    }
+
+    public function down(): void
+    {
+        DB::statement("DROP INDEX IF EXISTS locations_user_created_idx");
+        DB::statement("DROP INDEX IF EXISTS locations_jornada_registrado_idx");
+
+        Schema::table('locations', function (Blueprint $table) {
+            if (Schema::hasColumn('locations', 'jornada_id')) {
+                $table->dropConstrainedForeignId('jornada_id');
+            }
+            foreach (['registrado_en', 'velocidad', 'precision'] as $col) {
+                if (Schema::hasColumn('locations', $col)) $table->dropColumn($col);
+            }
+        });
+
+        Schema::table('last_locations', function (Blueprint $table) {
+            foreach (['registrado_en', 'velocidad', 'precision'] as $col) {
+                if (Schema::hasColumn('last_locations', $col)) $table->dropColumn($col);
+            }
+        });
+    }
+};

--- a/database/migrations/2026_01_03_000005_create_rutas_table.php
+++ b/database/migrations/2026_01_03_000005_create_rutas_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('rutas')) {
+            Schema::create('rutas', function (Blueprint $table) {
+                $table->id();
+                $table->string('nombre');
+                $table->text('descripcion')->nullable();
+
+                $table->foreignId('sucursal_id')
+                    ->constrained('sucursales')
+                    ->restrictOnDelete();
+
+                $table->boolean('activa')->default(true);
+
+                $table->timestamps();
+
+                $table->index('sucursal_id');
+                $table->index('activa');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rutas');
+    }
+};

--- a/database/migrations/2026_01_03_000006_create_asignaciones_rutas_table.php
+++ b/database/migrations/2026_01_03_000006_create_asignaciones_rutas_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('asignaciones_rutas')) {
+            Schema::create('asignaciones_rutas', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('ruta_id')
+                    ->constrained('rutas')
+                    ->cascadeOnDelete();
+
+                $table->foreignId('usuario_id')
+                    ->constrained('users')
+                    ->cascadeOnDelete();
+
+                $table->date('fecha_inicio');
+                $table->date('fecha_fin')->nullable();
+                $table->boolean('activa')->default(true);
+
+                $table->timestamps();
+
+                $table->unique(['ruta_id', 'usuario_id', 'fecha_inicio'], 'asig_ruta_usuario_inicio_unique');
+                $table->index(['usuario_id', 'activa']);
+                $table->index(['ruta_id', 'activa']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('asignaciones_rutas');
+    }
+};

--- a/database/migrations/2026_01_03_000007_create_categorias_clientes_table.php
+++ b/database/migrations/2026_01_03_000007_create_categorias_clientes_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('categorias_clientes')) {
+            Schema::create('categorias_clientes', function (Blueprint $table) {
+                $table->id();
+                $table->string('nombre')->unique();
+                $table->text('descripcion')->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categorias_clientes');
+    }
+};

--- a/database/migrations/2026_01_03_000008_create_clientes_table.php
+++ b/database/migrations/2026_01_03_000008_create_clientes_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('clientes')) {
+            Schema::create('clientes', function (Blueprint $table) {
+                $table->id();
+
+                $table->string('codigo', 50)->nullable(); // AA|AAA|A|B
+                $table->string('abreviatura', 100)->nullable();
+                $table->string('nombre');
+                $table->string('especialidad')->nullable();
+                $table->text('descripcion')->nullable();
+
+                $table->string('direccion')->nullable();
+                $table->decimal('latitud', 10, 7)->nullable();
+                $table->decimal('longitud', 10, 7)->nullable();
+
+                $table->foreignId('categoria_id')
+                    ->nullable()
+                    ->constrained('categorias_clientes')
+                    ->nullOnDelete();
+
+                $table->boolean('activo')->default(true);
+
+                $table->timestamps();
+
+                $table->index('categoria_id');
+                $table->index('codigo');
+                $table->index('activo');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clientes');
+    }
+};

--- a/database/migrations/2026_01_03_000009_create_ruta_clientes_table.php
+++ b/database/migrations/2026_01_03_000009_create_ruta_clientes_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('ruta_clientes')) {
+            Schema::create('ruta_clientes', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('ruta_id')
+                    ->constrained('rutas')
+                    ->cascadeOnDelete();
+
+                $table->foreignId('cliente_id')
+                    ->constrained('clientes')
+                    ->cascadeOnDelete();
+
+                $table->unsignedInteger('orden')->default(1);
+
+                $table->timestamps();
+
+                $table->unique(['ruta_id', 'cliente_id'], 'ruta_clientes_unique');
+                $table->index(['ruta_id', 'orden']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ruta_clientes');
+    }
+};

--- a/database/migrations/2026_01_03_000010_create_visitas_table.php
+++ b/database/migrations/2026_01_03_000010_create_visitas_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('visitas')) {
+            Schema::create('visitas', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('usuario_id')
+                    ->constrained('users')
+                    ->cascadeOnDelete();
+
+                $table->foreignId('cliente_id')
+                    ->constrained('clientes')
+                    ->restrictOnDelete();
+
+                $table->foreignId('jornada_id')
+                    ->constrained('jornadas')
+                    ->cascadeOnDelete();
+
+                $table->foreignId('ruta_id')
+                    ->nullable()
+                    ->constrained('rutas')
+                    ->nullOnDelete();
+
+                $table->timestamp('check_in')->nullable();
+                $table->timestamp('check_out')->nullable();
+
+                $table->decimal('latitud', 10, 7)->nullable();
+                $table->decimal('longitud', 10, 7)->nullable();
+
+                $table->text('notas')->nullable();
+
+                $table->timestamps();
+
+                $table->index(['usuario_id', 'jornada_id']);
+                $table->index('cliente_id');
+                $table->index('check_in');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('visitas');
+    }
+};

--- a/database/migrations/2026_01_03_000011_create_muestras_medicas_table.php
+++ b/database/migrations/2026_01_03_000011_create_muestras_medicas_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('muestras_medicas')) {
+            Schema::create('muestras_medicas', function (Blueprint $table) {
+                $table->id();
+                $table->string('nombre');
+                $table->string('tipo')->nullable();
+                $table->text('descripcion')->nullable();
+                $table->boolean('activa')->default(true);
+                $table->timestamps();
+
+                $table->index('activa');
+                $table->index('nombre');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('muestras_medicas');
+    }
+};

--- a/database/migrations/2026_01_03_000012_create_inventarios_sucursales_muestras_table.php
+++ b/database/migrations/2026_01_03_000012_create_inventarios_sucursales_muestras_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('inventarios_sucursales_muestras')) {
+            Schema::create('inventarios_sucursales_muestras', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('sucursal_id')
+                    ->constrained('sucursales')
+                    ->cascadeOnDelete();
+
+                $table->foreignId('muestra_medica_id')
+                    ->constrained('muestras_medicas')
+                    ->restrictOnDelete();
+
+                $table->integer('cantidad')->default(0);
+                $table->timestamps();
+
+                $table->unique(['sucursal_id', 'muestra_medica_id'], 'inv_sucursal_muestra_unique');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('inventarios_sucursales_muestras');
+    }
+};

--- a/database/migrations/2026_01_03_000013_create_inventarios_visitadores_muestras_table.php
+++ b/database/migrations/2026_01_03_000013_create_inventarios_visitadores_muestras_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('inventarios_visitadores_muestras')) {
+            Schema::create('inventarios_visitadores_muestras', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('usuario_id')
+                    ->constrained('users')
+                    ->cascadeOnDelete();
+
+                $table->foreignId('muestra_medica_id')
+                    ->constrained('muestras_medicas')
+                    ->restrictOnDelete();
+
+                $table->integer('cantidad')->default(0);
+                $table->timestamps();
+
+                $table->unique(['usuario_id', 'muestra_medica_id'], 'inv_visitador_muestra_unique');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('inventarios_visitadores_muestras');
+    }
+};

--- a/database/migrations/2026_01_03_000014_create_operaciones_table.php
+++ b/database/migrations/2026_01_03_000014_create_operaciones_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('operaciones')) {
+            Schema::create('operaciones', function (Blueprint $table) {
+                $table->id();
+
+                $table->timestamp('fecha_registro'); // fecha de registro
+                $table->string('tipo', 50); // entrega|devolucion|ajuste
+                $table->string('comprobante')->nullable();
+
+                $table->foreignId('sucursal_id')
+                    ->constrained('sucursales')
+                    ->restrictOnDelete();
+
+                $table->foreignId('entrega_usuario_id')
+                    ->nullable()
+                    ->constrained('users')
+                    ->nullOnDelete();
+
+                $table->foreignId('recibe_usuario_id')
+                    ->nullable()
+                    ->constrained('users')
+                    ->nullOnDelete();
+
+                $table->integer('total_unidades')->default(0);
+                $table->text('observacion')->nullable();
+
+                $table->timestamps();
+
+                $table->index(['sucursal_id', 'fecha_registro']);
+                $table->index(['tipo', 'fecha_registro']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('operaciones');
+    }
+};

--- a/database/migrations/2026_01_03_000015_create_operaciones_items_table.php
+++ b/database/migrations/2026_01_03_000015_create_operaciones_items_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('operaciones_items')) {
+            Schema::create('operaciones_items', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('operacion_id')
+                    ->constrained('operaciones')
+                    ->cascadeOnDelete();
+
+                $table->foreignId('muestra_medica_id')
+                    ->constrained('muestras_medicas')
+                    ->restrictOnDelete();
+
+                $table->integer('cantidad');
+                $table->timestamps();
+
+                $table->index('operacion_id');
+                $table->index('muestra_medica_id');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('operaciones_items');
+    }
+};


### PR DESCRIPTION
## PR: Migraciones completas + actualización de modelos

### Hecho
- Se agregaron **migraciones** (nuevas tablas ES + columnas nuevas en tablas EN).
- `users.estado` default **OFF**.
- Backfill: `registrado_en = created_at` en `locations` y `last_locations`.
- Se actualizaron modelos (`$fillable` + relaciones/imports) para compatibilidad con Filament.

### Verificado
- Migraciones corren sin errores
- API/app existente sigue operando (login + tracking)
