### PR TITLE
FEATURE/ agregar modelo para Rutas

### DIFF
--- a/app/Models/Ruta.php
+++ b/app/Models/Ruta.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Ruta extends Model
+{
+    use HasFactory;
+
+    protected $table = 'rutas';
+
+    protected $fillable = [
+        'nombre',
+        'descripcion',
+        'sucursal_id',
+        'activa',
+    ];
+
+    protected $casts = [
+        'activa' => 'boolean',
+    ];
+
+    public function sucursal(): BelongsTo
+    {
+        return $this->belongsTo(Sucursal::class, 'sucursal_id');
+    }
+
+    public function clientesRuta(): HasMany
+    {
+        // RutaCliente se crea en otro issue; por ahora queda la relación lista
+        return $this->hasMany(RutaCliente::class, 'ruta_id');
+    }
+
+    public function asignaciones(): HasMany
+    {
+        // AsignacionRuta se crea en otro issue
+        return $this->hasMany(AsignacionRuta::class, 'ruta_id');
+    }
+
+    public function visitas(): HasMany
+    {
+        // Visita se crea en otro issue
+        return $this->hasMany(Visita::class, 'ruta_id');
+    }
+}

--- a/database/factories/RutaFactory.php
+++ b/database/factories/RutaFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Ruta;
+use App\Models\Sucursal;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Ruta>
+ */
+class RutaFactory extends Factory
+{
+    protected $model = Ruta::class;
+
+    public function definition(): array
+    {
+        return [
+            'nombre' => 'Ruta ' . fake()->city(),
+            'descripcion' => fake()->optional()->sentence(),
+            'sucursal_id' => Sucursal::factory(),
+            'activa' => true,
+        ];
+    }
+
+    public function inactiva(): self
+    {
+        return $this->state(fn () => ['activa' => false]);
+    }
+}

--- a/tests/Unit/RutaTest.php
+++ b/tests/Unit/RutaTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Ruta;
+use App\Models\Sucursal;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class RutaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Si los tests usan sqlite, habilita FK.
+        if (config('database.default') === 'sqlite') {
+            DB::statement('PRAGMA foreign_keys=ON;');
+        }
+    }
+
+    public function test_factory_crea_ruta_valida(): void
+    {
+        $ruta = Ruta::factory()->create();
+
+        $this->assertNotNull($ruta->id);
+        $this->assertNotEmpty($ruta->nombre);
+        $this->assertTrue(is_bool($ruta->activa));
+
+        $this->assertDatabaseHas('rutas', [
+            'id' => $ruta->id,
+            'nombre' => $ruta->nombre,
+            'sucursal_id' => $ruta->sucursal_id,
+        ]);
+    }
+
+    public function test_cast_activa_es_boolean(): void
+    {
+        $ruta = Ruta::factory()->create(['activa' => 1]);
+        $this->assertIsBool($ruta->activa);
+        $this->assertTrue($ruta->activa);
+
+        $ruta2 = Ruta::factory()->inactiva()->create();
+        $this->assertIsBool($ruta2->activa);
+        $this->assertFalse($ruta2->activa);
+    }
+
+    public function test_relacion_sucursal_es_belongsTo_y_funciona(): void
+    {
+        $sucursal = Sucursal::factory()->create();
+        $ruta = Ruta::factory()->create(['sucursal_id' => $sucursal->id]);
+
+        $this->assertInstanceOf(BelongsTo::class, $ruta->sucursal());
+        $this->assertSame($sucursal->id, $ruta->sucursal->id);
+    }
+
+    public function test_se_puede_crear_por_mass_assignment(): void
+    {
+        $sucursal = Sucursal::factory()->create();
+
+        $ruta = Ruta::create([
+            'nombre' => 'Ruta Norte',
+            'descripcion' => 'Zona norte - clientes VIP',
+            'sucursal_id' => $sucursal->id,
+            'activa' => true,
+        ]);
+
+        $this->assertDatabaseHas('rutas', [
+            'id' => $ruta->id,
+            'nombre' => 'Ruta Norte',
+            'sucursal_id' => $sucursal->id,
+        ]);
+    }
+
+    public function test_update_ruta(): void
+    {
+        $ruta = Ruta::factory()->create(['nombre' => 'Ruta A']);
+
+        $ruta->update([
+            'nombre' => 'Ruta A (Actualizada)',
+            'activa' => false,
+        ]);
+
+        $this->assertDatabaseHas('rutas', [
+            'id' => $ruta->id,
+            'nombre' => 'Ruta A (Actualizada)',
+            'activa' => false,
+        ]);
+    }
+
+    public function test_no_permite_sucursal_id_inexistente(): void
+    {
+        $this->expectException(QueryException::class);
+
+        Ruta::create([
+            'nombre' => 'Ruta inválida',
+            'descripcion' => null,
+            'sucursal_id' => 999999, // no existe
+            'activa' => true,
+        ]);
+    }
+
+    public function test_no_permite_nombre_null(): void
+    {
+        $this->expectException(QueryException::class);
+
+        $sucursal = Sucursal::factory()->create();
+
+        Ruta::create([
+            'nombre' => null,
+            'descripcion' => null,
+            'sucursal_id' => $sucursal->id,
+            'activa' => true,
+        ]);
+    }
+
+    public function test_no_se_puede_eliminar_sucursal_si_tiene_rutas_restrict(): void
+    {
+        // Esto valida el restrictOnDelete() de la FK
+        $this->expectException(QueryException::class);
+
+        $sucursal = Sucursal::factory()->create();
+        Ruta::factory()->create(['sucursal_id' => $sucursal->id]);
+
+        $sucursal->delete(); // debería fallar por RESTRICT
+    }
+}


### PR DESCRIPTION
# Pull Request: Crear Modelo Ruta 

## Resumen
Se implementó el módulo **Ruta** (tabla `rutas`) con su **migración**, **modelo**, **factory** y **unit test completo**, incluyendo relación con `sucursales` y validaciones de FK.

## Cambios incluidos
- ✅ Migración: `create_rutas_table` (FK `sucursal_id` → `sucursales` con `restrictOnDelete`)
- ✅ Modelo: `app/Models/Ruta.php` (casts `activa` boolean + relaciones)
- ✅ Factory: `database/factories/RutaFactory.php`
- ✅ Test unitario: `tests/Unit/RutaTest.php` (CRUD + casts + FK + restrict delete)

## Cómo probar
```bash
php artisan migrate
php artisan test --filter=RutaTest
