### PR TITLE
FEATURE/ Crear Modelo for RutaCliente

### DIFF
--- a/app/Models/RutaCliente.php
+++ b/app/Models/RutaCliente.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RutaCliente extends Model
+{
+    use HasFactory;
+
+    protected $table = 'ruta_clientes';
+
+    protected $fillable = [
+        'ruta_id',
+        'cliente_id',
+        'orden',
+    ];
+
+    protected $casts = [
+        'orden' => 'integer',
+    ];
+
+    public function ruta(): BelongsTo
+    {
+        return $this->belongsTo(Ruta::class, 'ruta_id');
+    }
+
+    public function cliente(): BelongsTo
+    {
+        return $this->belongsTo(Cliente::class, 'cliente_id');
+    }
+}

--- a/database/factories/RutaClienteFactory.php
+++ b/database/factories/RutaClienteFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Ruta;
+use App\Models\Cliente;
+use App\Models\RutaCliente;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RutaCliente>
+ */
+class RutaClienteFactory extends Factory
+{
+    protected $model = RutaCliente::class;
+
+    public function definition(): array
+    {
+        return [
+            'ruta_id' => Ruta::factory(),
+            'cliente_id' => Cliente::factory(),
+            'orden' => $this->faker->numberBetween(1, 50),
+        ];
+    }
+}

--- a/tests/Unit/RutaClienteTest.php
+++ b/tests/Unit/RutaClienteTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Cliente;
+use App\Models\Ruta;
+use App\Models\RutaCliente;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class RutaClienteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Para que FK funcione si el entorno de test usa sqlite
+        if (config('database.default') === 'sqlite') {
+            DB::statement('PRAGMA foreign_keys=ON;');
+        }
+    }
+
+    public function test_crea_ruta_cliente_con_factory(): void
+    {
+        $pivot = RutaCliente::factory()->create();
+
+        $this->assertNotNull($pivot->id);
+        $this->assertDatabaseHas('ruta_clientes', [
+            'id' => $pivot->id,
+            'ruta_id' => $pivot->ruta_id,
+            'cliente_id' => $pivot->cliente_id,
+        ]);
+    }
+
+    public function test_relaciones_son_belongs_to(): void
+    {
+        $pivot = RutaCliente::factory()->create();
+
+        $this->assertInstanceOf(BelongsTo::class, $pivot->ruta());
+        $this->assertInstanceOf(BelongsTo::class, $pivot->cliente());
+
+        $this->assertInstanceOf(Ruta::class, $pivot->ruta);
+        $this->assertInstanceOf(Cliente::class, $pivot->cliente);
+    }
+
+    public function test_default_orden_es_1_cuando_no_se_envia(): void
+    {
+        $ruta = Ruta::factory()->create();
+        $cliente = Cliente::factory()->create();
+
+        $pivot = RutaCliente::create([
+            'ruta_id' => $ruta->id,
+            'cliente_id' => $cliente->id,
+            // no enviamos 'orden'
+        ]);
+
+        $pivot->refresh();
+        $this->assertSame(1, (int) $pivot->orden);
+    }
+
+    public function test_update_de_orden_funciona(): void
+    {
+        $pivot = RutaCliente::factory()->create(['orden' => 1]);
+
+        $pivot->update(['orden' => 10]);
+
+        $this->assertDatabaseHas('ruta_clientes', [
+            'id' => $pivot->id,
+            'orden' => 10,
+        ]);
+    }
+
+    public function test_unique_ruta_id_cliente_id_no_permite_duplicados(): void
+    {
+        $this->expectException(QueryException::class);
+
+        $ruta = Ruta::factory()->create();
+        $cliente = Cliente::factory()->create();
+
+        RutaCliente::create([
+            'ruta_id' => $ruta->id,
+            'cliente_id' => $cliente->id,
+            'orden' => 1,
+        ]);
+
+        // duplicado debe fallar por unique
+        RutaCliente::create([
+            'ruta_id' => $ruta->id,
+            'cliente_id' => $cliente->id,
+            'orden' => 2,
+        ]);
+    }
+
+    public function test_al_eliminar_ruta_o_cliente_se_elimina_el_pivot_por_cascade(): void
+    {
+        $ruta = Ruta::factory()->create();
+        $cliente = Cliente::factory()->create();
+
+        $pivot = RutaCliente::create([
+            'ruta_id' => $ruta->id,
+            'cliente_id' => $cliente->id,
+            'orden' => 1,
+        ]);
+
+        $this->assertDatabaseHas('ruta_clientes', ['id' => $pivot->id]);
+
+        // Al borrar ruta -> cascade elimina pivots
+        $ruta->delete();
+
+        $this->assertDatabaseMissing('ruta_clientes', ['id' => $pivot->id]);
+    }
+}


### PR DESCRIPTION
# PR: Crear Modelo RutaCliente (pivot) 

## Resumen
Se implementó **RutaCliente** (tabla pivote `ruta_clientes`) para asignar **clientes** a **rutas** con un campo `orden` (orden de visita).

## Cambios incluidos
- ✅ Migración: `create_ruta_clientes_table`
  - FKs: `ruta_id` → `rutas`, `cliente_id` → `clientes`
  - `orden` con default `1`
  - Unique: `(ruta_id, cliente_id)`
  - Index: `(ruta_id, orden)`
  - Cascades: al eliminar ruta/cliente se elimina el pivot
- ✅ Modelo: `RutaCliente`
  - `$fillable`: `ruta_id`, `cliente_id`, `orden`
  - Relaciones: `ruta()` y `cliente()`
- ✅ Factory: `RutaClienteFactory`
- ✅ Unit Test completo: `RutaClienteTest`
  - create por factory
  - relaciones belongsTo
  - default `orden = 1`
  - update de orden
  - restricción unique
  - cascade delete

## Cómo probar
```bash
php artisan migrate
php artisan test --filter=RutaClienteTest
