### PR TITLE
FEATURE/ Crear Modelo InventarioSucursalMuestra

### DIFF
--- a/app/Models/InventarioSucursalMuestra.php
+++ b/app/Models/InventarioSucursalMuestra.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InventarioSucursalMuestra extends Model
+{
+    use HasFactory;
+
+    protected $table = 'inventarios_sucursales_muestras';
+
+    protected $fillable = [
+        'sucursal_id',
+        'muestra_medica_id',
+        'cantidad',
+    ];
+
+    protected $casts = [
+        'cantidad' => 'integer',
+    ];
+
+    public function sucursal(): BelongsTo
+    {
+        return $this->belongsTo(Sucursal::class, 'sucursal_id');
+    }
+
+    public function muestraMedica(): BelongsTo
+    {
+        return $this->belongsTo(MuestraMedica::class, 'muestra_medica_id');
+    }
+}

--- a/database/factories/InventarioSucursalMuestraFactory.php
+++ b/database/factories/InventarioSucursalMuestraFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\InventarioSucursalMuestra;
+use App\Models\Sucursal;
+use App\Models\MuestraMedica;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\InventarioSucursalMuestra>
+ */
+class InventarioSucursalMuestraFactory extends Factory
+{
+    protected $model = InventarioSucursalMuestra::class;
+
+    public function definition(): array
+    {
+        return [
+            'sucursal_id' => Sucursal::factory(),
+            'muestra_medica_id' => MuestraMedica::factory(),
+            'cantidad' => fake()->numberBetween(0, 500),
+        ];
+    }
+}

--- a/tests/Unit/InventarioSucursalMuestraTest.php
+++ b/tests/Unit/InventarioSucursalMuestraTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\InventarioSucursalMuestra;
+use App\Models\MuestraMedica;
+use App\Models\Sucursal;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class InventarioSucursalMuestraTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Para que funcionen FK en SQLite (si tu entorno de tests usa sqlite)
+        if (config('database.default') === 'sqlite') {
+            DB::statement('PRAGMA foreign_keys=ON;');
+        }
+    }
+
+    public function test_factory_crea_registro_valido(): void
+    {
+        $inv = InventarioSucursalMuestra::factory()->create();
+
+        $this->assertNotNull($inv->id);
+        $this->assertIsInt($inv->cantidad);
+
+        $this->assertDatabaseHas('inventarios_sucursales_muestras', [
+            'id' => $inv->id,
+            'sucursal_id' => $inv->sucursal_id,
+            'muestra_medica_id' => $inv->muestra_medica_id,
+        ]);
+    }
+
+    public function test_relaciones_son_belongsTo_y_funcionan(): void
+    {
+        $inv = InventarioSucursalMuestra::factory()->create();
+
+        $this->assertInstanceOf(BelongsTo::class, $inv->sucursal());
+        $this->assertInstanceOf(BelongsTo::class, $inv->muestraMedica());
+
+        $this->assertNotNull($inv->sucursal);
+        $this->assertNotNull($inv->muestraMedica);
+    }
+
+    public function test_se_puede_actualizar_cantidad(): void
+    {
+        $inv = InventarioSucursalMuestra::factory()->create(['cantidad' => 10]);
+
+        $inv->update(['cantidad' => 25]);
+
+        $this->assertDatabaseHas('inventarios_sucursales_muestras', [
+            'id' => $inv->id,
+            'cantidad' => 25,
+        ]);
+    }
+
+    public function test_unique_sucursal_muestra_no_permiteduplicados(): void
+    {
+        $sucursal = Sucursal::factory()->create();
+        $muestra = MuestraMedica::factory()->create();
+
+        InventarioSucursalMuestra::create([
+            'sucursal_id' => $sucursal->id,
+            'muestra_medica_id' => $muestra->id,
+            'cantidad' => 1,
+        ]);
+
+        $this->expectException(QueryException::class);
+
+        InventarioSucursalMuestra::create([
+            'sucursal_id' => $sucursal->id,
+            'muestra_medica_id' => $muestra->id,
+            'cantidad' => 2,
+        ]);
+    }
+
+    public function test_eliminar_sucursal_elimina_inventario_por_cascade(): void
+    {
+        $inv = InventarioSucursalMuestra::factory()->create();
+        $invId = $inv->id;
+
+        $inv->sucursal->delete();
+
+        $this->assertDatabaseMissing('inventarios_sucursales_muestras', [
+            'id' => $invId,
+        ]);
+    }
+
+    public function test_no_permitedelete_muestra_medica_si_existe_inventario_restrict(): void
+    {
+        $inv = InventarioSucursalMuestra::factory()->create();
+
+        $this->expectException(QueryException::class);
+
+        $inv->muestraMedica->delete();
+    }
+}


### PR DESCRIPTION
# Pull Request: Crear modelo InventarioSucursalMuestra

## Resumen
Se añadió el modelo **InventarioSucursalMuestra** para manejar el stock de muestras médicas por sucursal.

## Cambios incluidos
- ✅ Modelo: `app/Models/InventarioSucursalMuestra.php`
- ✅ Migración: `create_inventarios_sucursales_muestras_table`
- ✅ Factory: `database/factories/InventarioSucursalMuestraFactory.php`
- ✅ Unit Test completo: `tests/Unit/InventarioSucursalMuestraTest.php`

## Estructura (inventarios_sucursales_muestras)
- `sucursal_id` (FK → `sucursales`, **cascadeOnDelete**)
- `muestra_medica_id` (FK → `muestras_medicas`, **restrictOnDelete**)
- `cantidad` (default `0`)
- Unique: `(sucursal_id, muestra_medica_id)`

## Cómo probar
```bash
php artisan migrate
php artisan test --filter=InventarioSucursalMuestraTest
