### PR TITLE
FEATURE/ Crear Modelo para Visitas

### DIFF
--- a/app/Models/Visita.php
+++ b/app/Models/Visita.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Visita extends Model
+{
+    use HasFactory;
+
+    protected $table = 'visitas';
+
+    protected $fillable = [
+        'usuario_id',
+        'cliente_id',
+        'jornada_id',
+        'ruta_id',
+        'check_in',
+        'check_out',
+        'latitud',
+        'longitud',
+        'notas',
+    ];
+
+    protected $casts = [
+        'check_in' => 'datetime',
+        'check_out' => 'datetime',
+        'latitud' => 'float',
+        'longitud' => 'float',
+    ];
+
+    public function usuario(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'usuario_id');
+    }
+
+    public function cliente(): BelongsTo
+    {
+        return $this->belongsTo(Cliente::class, 'cliente_id');
+    }
+
+    public function jornada(): BelongsTo
+    {
+        return $this->belongsTo(Jornada::class, 'jornada_id');
+    }
+
+    public function ruta(): BelongsTo
+    {
+        return $this->belongsTo(Ruta::class, 'ruta_id');
+    }
+}

--- a/database/factories/VisitaFactory.php
+++ b/database/factories/VisitaFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Cliente;
+use App\Models\Jornada;
+use App\Models\Ruta;
+use App\Models\User;
+use App\Models\Visita;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Visita>
+ */
+class VisitaFactory extends Factory
+{
+    protected $model = Visita::class;
+
+    public function definition(): array
+    {
+        $checkIn = fake()->dateTimeBetween('-2 days', 'now');
+
+        return [
+            'usuario_id' => User::factory(),
+            'cliente_id' => Cliente::factory(),
+            'jornada_id' => Jornada::factory(),
+            'ruta_id' => Ruta::factory(), // puedes setear null con state()
+            'check_in' => $checkIn,
+            'check_out' => fake()->dateTimeBetween($checkIn, '+3 hours'),
+            'latitud' => fake()->latitude(-17.6, -17.2),   // rango aproximado CBBA
+            'longitud' => fake()->longitude(-66.4, -65.9), // rango aproximado CBBA
+            'notas' => fake()->optional()->sentence(),
+        ];
+    }
+
+    public function sinRuta(): static
+    {
+        return $this->state(fn () => ['ruta_id' => null]);
+    }
+
+    public function soloCheckIn(): static
+    {
+        return $this->state(function () {
+            return ['check_out' => null];
+        });
+    }
+}

--- a/tests/Unit/VisitaTest.php
+++ b/tests/Unit/VisitaTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Cliente;
+use App\Models\Jornada;
+use App\Models\Ruta;
+use App\Models\User;
+use App\Models\Visita;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class VisitaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Para SQLite en tests (si aplica)
+        if (config('database.default') === 'sqlite') {
+            DB::statement('PRAGMA foreign_keys=ON;');
+        }
+    }
+
+    public function test_factory_crea_visita_valida(): void
+    {
+        $visita = Visita::factory()->create();
+
+        $this->assertDatabaseHas('visitas', [
+            'id' => $visita->id,
+            'usuario_id' => $visita->usuario_id,
+            'cliente_id' => $visita->cliente_id,
+            'jornada_id' => $visita->jornada_id,
+        ]);
+    }
+
+    public function test_relaciones_son_belongsTo(): void
+    {
+        $visita = Visita::factory()->create();
+
+        $this->assertInstanceOf(BelongsTo::class, $visita->usuario());
+        $this->assertInstanceOf(BelongsTo::class, $visita->cliente());
+        $this->assertInstanceOf(BelongsTo::class, $visita->jornada());
+        $this->assertInstanceOf(BelongsTo::class, $visita->ruta());
+    }
+
+    public function test_se_puede_crear_visita_sin_ruta(): void
+    {
+        $usuario = User::factory()->create();
+        $cliente = Cliente::factory()->create();
+        $jornada = Jornada::factory()->create(['usuario_id' => $usuario->id]);
+
+        $visita = Visita::create([
+            'usuario_id' => $usuario->id,
+            'cliente_id' => $cliente->id,
+            'jornada_id' => $jornada->id,
+            'ruta_id' => null,
+            'check_in' => now(),
+            'check_out' => null,
+            'latitud' => -17.39,
+            'longitud' => -66.16,
+            'notas' => 'Visita sin ruta asignada',
+        ]);
+
+        $this->assertDatabaseHas('visitas', [
+            'id' => $visita->id,
+            'ruta_id' => null,
+        ]);
+    }
+
+    public function test_casts_datetime_y_float_funcionan(): void
+    {
+        $visita = Visita::factory()->soloCheckIn()->create([
+            'latitud' => '-17.3900000',
+            'longitud' => '-66.1600000',
+        ]);
+
+        $this->assertIsFloat($visita->latitud);
+        $this->assertIsFloat($visita->longitud);
+        $this->assertNotNull($visita->check_in);
+        $this->assertNull($visita->check_out);
+    }
+
+    public function test_fk_obligatorias_no_permiten_null(): void
+    {
+        $this->expectException(QueryException::class);
+
+        Visita::create([
+            'usuario_id' => null,
+            'cliente_id' => null,
+            'jornada_id' => null,
+        ]);
+    }
+
+    public function test_borrado_de_jornada_cascade_elimina_visitas(): void
+    {
+        $usuario = User::factory()->create();
+        $cliente = Cliente::factory()->create();
+        $ruta = Ruta::factory()->create();
+        $jornada = Jornada::factory()->create(['usuario_id' => $usuario->id]);
+
+        $visita = Visita::factory()->create([
+            'usuario_id' => $usuario->id,
+            'cliente_id' => $cliente->id,
+            'jornada_id' => $jornada->id,
+            'ruta_id' => $ruta->id,
+        ]);
+
+        $this->assertDatabaseHas('visitas', ['id' => $visita->id]);
+
+        $jornada->delete();
+
+        $this->assertDatabaseMissing('visitas', ['id' => $visita->id]);
+    }
+
+    public function test_borrado_de_ruta_setea_ruta_id_a_null(): void
+    {
+        $usuario = User::factory()->create();
+        $cliente = Cliente::factory()->create();
+        $ruta = Ruta::factory()->create();
+        $jornada = Jornada::factory()->create(['usuario_id' => $usuario->id]);
+
+        $visita = Visita::factory()->create([
+            'usuario_id' => $usuario->id,
+            'cliente_id' => $cliente->id,
+            'jornada_id' => $jornada->id,
+            'ruta_id' => $ruta->id,
+        ]);
+
+        $ruta->delete();
+
+        $visita->refresh();
+        $this->assertNull($visita->ruta_id);
+    }
+}


### PR DESCRIPTION
# Pull Request: Crear Modelo Visitas (check-in/out) 

## Resumen
Se implementa el módulo **Visita** para registrar **check-in/check-out** de clientes durante una **jornada**, con relación opcional a **ruta**.

## Cambios incluidos
- ✅ Migración: `visitas` con FKs (`users`, `clientes`, `jornadas`, `rutas` nullable)
- ✅ Modelo: `Visita` con `fillable`, `casts` y relaciones `belongsTo`
- ✅ Factory: `VisitaFactory` (incluye states `sinRuta()` y `soloCheckIn()`)
- ✅ Unit Test: `VisitaTest` (CRUD + casts + relaciones + comportamiento FK)

## Tablas afectadas
- `visitas` (nueva)

## Relaciones
- `visitas.usuario_id` → `users.id`
- `visitas.cliente_id` → `clientes.id`
- `visitas.jornada_id` → `jornadas.id`
- `visitas.ruta_id` → `rutas.id` (nullable, `nullOnDelete`)

## Cómo probar
```bash
php artisan migrate
php artisan test --filter=VisitaTest
