### PR TITLE
Feature/crear modelo operacion items

### DIFF
--- a/app/Models/Cliente.php
+++ b/app/Models/Cliente.php
@@ -37,7 +37,7 @@ class Cliente extends Model
     {
         return $this->belongsTo(CategoriaCliente::class, 'categoria_id');
     }
-/*
+
     public function visitas(): HasMany
     {
         return $this->hasMany(Visita::class, 'cliente_id');
@@ -50,6 +50,6 @@ class Cliente extends Model
             ->withPivot('orden')
             ->withTimestamps();
     }
-*/
+
 }
 

--- a/app/Models/Jornada.php
+++ b/app/Models/Jornada.php
@@ -43,12 +43,12 @@ class Jornada extends Model
         return $this->belongsTo(User::class, 'usuario_id');
     }
 
-/*    public function visitas(): HasMany
+    public function visitas(): HasMany
     {
         // Evita error si Visita aún no existe
         return $this->hasMany('App\\Models\\Visita', 'jornada_id');
     }
-*/
+
     public function locations(): HasMany
     {
         return $this->hasMany(Location::class, 'jornada_id');

--- a/app/Models/MuestraMedica.php
+++ b/app/Models/MuestraMedica.php
@@ -24,7 +24,7 @@ class MuestraMedica extends Model
     ];
 
     // Relaciones (se activan cuando existan estos modelos)
-/*
+
     public function inventariosSucursales(): HasMany
     {
         return $this->hasMany(InventarioSucursalMuestra::class, 'muestra_medica_id');
@@ -39,5 +39,5 @@ class MuestraMedica extends Model
     {
         return $this->hasMany(OperacionItem::class, 'muestra_medica_id');
     }
-*/
+
 }

--- a/app/Models/OperacionItem.php
+++ b/app/Models/OperacionItem.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OperacionItem extends Model
+{
+    use HasFactory;
+
+    protected $table = 'operaciones_items';
+
+    protected $fillable = [
+        'operacion_id',
+        'muestra_medica_id',
+        'cantidad',
+    ];
+
+    protected $casts = [
+        'cantidad' => 'integer',
+    ];
+
+    public function operacion(): BelongsTo
+    {
+        return $this->belongsTo(Operacion::class, 'operacion_id');
+    }
+
+    public function muestraMedica(): BelongsTo
+    {
+        return $this->belongsTo(MuestraMedica::class, 'muestra_medica_id');
+    }
+}

--- a/database/factories/OperacionItemFactory.php
+++ b/database/factories/OperacionItemFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\MuestraMedica;
+use App\Models\Operacion;
+use App\Models\OperacionItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\OperacionItem>
+ */
+class OperacionItemFactory extends Factory
+{
+    protected $model = OperacionItem::class;
+
+    public function definition(): array
+    {
+        return [
+            'operacion_id' => Operacion::factory(),
+            'muestra_medica_id' => MuestraMedica::factory(),
+            'cantidad' => fake()->numberBetween(1, 100),
+        ];
+    }
+}

--- a/tests/Unit/ClienteTest.php
+++ b/tests/Unit/ClienteTest.php
@@ -84,14 +84,14 @@ class ClienteTest extends TestCase
         $cliente = Cliente::factory()->create();
 
         // Evita fallas si aún no creaste Ruta/Visita en tu proyecto.
-    /*    if (class_exists(\App\Models\Visita::class)) {
+        if (class_exists(\App\Models\Visita::class)) {
             $this->assertTrue(method_exists($cliente, 'visitas'));
         }
 
         if (class_exists(\App\Models\Ruta::class)) {
             $this->assertTrue(method_exists($cliente, 'rutas'));
         }
-*/
+
         $this->assertTrue(method_exists($cliente, 'categoria'));
     }
 }

--- a/tests/Unit/MuestraMedicaTest.php
+++ b/tests/Unit/MuestraMedicaTest.php
@@ -73,7 +73,7 @@ class MuestraMedicaTest extends TestCase
         ]);
     }
 
-/*    public function test_relaciones_existen_y_funcionan_si_los_modelos_dependientes_ya_existen(): void
+    public function test_relaciones_existen_y_funcionan_si_los_modelos_dependientes_ya_existen(): void
     {
         // Si todavía no creaste estos modelos, este test se salta sin fallar.
         $dependencias = [
@@ -94,5 +94,5 @@ class MuestraMedicaTest extends TestCase
         $this->assertNotNull($muestra->inventariosVisitadores());
         $this->assertNotNull($muestra->operacionesItems());
     }
-*/
+
 }

--- a/tests/Unit/OperacionItemTest.php
+++ b/tests/Unit/OperacionItemTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\MuestraMedica;
+use App\Models\Operacion;
+use App\Models\OperacionItem;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class OperacionItemTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Para SQLite en tests (si aplica)
+        if (config('database.default') === 'sqlite') {
+            DB::statement('PRAGMA foreign_keys=ON;');
+        }
+    }
+
+    public function test_factory_crea_item_valido(): void
+    {
+        $item = OperacionItem::factory()->create();
+
+        $this->assertDatabaseHas('operaciones_items', [
+            'id' => $item->id,
+            'operacion_id' => $item->operacion_id,
+            'muestra_medica_id' => $item->muestra_medica_id,
+            'cantidad' => $item->cantidad,
+        ]);
+    }
+
+    public function test_relaciones_son_belongsTo(): void
+    {
+        $item = OperacionItem::factory()->create();
+
+        $this->assertInstanceOf(BelongsTo::class, $item->operacion());
+        $this->assertInstanceOf(BelongsTo::class, $item->muestraMedica());
+    }
+
+    public function test_fk_son_obligatorias(): void
+    {
+        $this->expectException(QueryException::class);
+
+        OperacionItem::create([
+            'operacion_id' => null,
+            'muestra_medica_id' => null,
+            'cantidad' => 10,
+        ]);
+    }
+
+    public function test_al_borrar_operacion_se_eliminan_sus_items(): void
+    {
+        $op = Operacion::factory()->create();
+
+        $item = OperacionItem::factory()->create([
+            'operacion_id' => $op->id,
+        ]);
+
+        $this->assertDatabaseHas('operaciones_items', ['id' => $item->id]);
+
+        $op->delete();
+
+        $this->assertDatabaseMissing('operaciones_items', ['id' => $item->id]);
+    }
+
+    public function test_no_se_puede_borrar_muestra_medica_si_esta_usada_en_items(): void
+    {
+        $muestra = MuestraMedica::factory()->create();
+
+        OperacionItem::factory()->create([
+            'muestra_medica_id' => $muestra->id,
+        ]);
+
+        $this->expectException(QueryException::class);
+        $muestra->delete();
+    }
+}


### PR DESCRIPTION
# Pull Request: Crear modelo OperacionItem (detalle)

## Resumen
Se creó el modelo **OperacionItem** (detalle) para registrar los ítems de una operación.

## Cambios
- ✅ Modelo: `app/Models/OperacionItem.php`
- ✅ Relaciones:
  - `belongsTo` operación (`operacion_id`)
  - `belongsTo` muestra médica (`muestra_medica_id`)

## Cómo probar
```bash
php artisan test --filter=OperacionTest